### PR TITLE
:zap: Add font swap property

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,0 +1,26 @@
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link
+            href="https://fonts.googleapis.com/css?family=Inter:100,200,300,regular,500,600,700,800,900&display=swap"
+            rel="stylesheet"
+          />
+          <link
+            href="https://fonts.googleapis.com/css?family=Space+Grotesk:300,regular,500,600,700&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,14 +23,6 @@ export default function Home() {
           content="Spekni is a hiring platform built for recruiters to find the best developers based on reputable endorsements."
         />
         <link rel="icon" href="/favicon.svg" />
-        <link
-          href="https://fonts.googleapis.com/css?family=Inter:100,200,300,regular,500,600,700,800,900"
-          rel="stylesheet"
-        />
-        <link
-          href="https://fonts.googleapis.com/css?family=Space+Grotesk:300,regular,500,600,700"
-          rel="stylesheet"
-        />
       </Head>
       {/* Markup */}
       {/* <main className={styles.main}> // ? Module styling (Don't delete) */}


### PR DESCRIPTION
Fixes NexJS font warning issue:

Warning: A font-display parameter is missing (adding `&display=optional` is recommended). See: https://nextjs.org/docs/messages/google-font-display  @next/next/google-font-display

30:9  Warning: Custom fonts not added in `pages/_document.js` will only load for a single page. This is discouraged. See: https://nextjs.org/docs/messages/no-page-custom-font  @next/next/no-page-custom-font